### PR TITLE
Fix bench print to display results of the last run

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,14 +39,14 @@ func main() {
 			for _, multiplier := range multiplier {
 				numKey := cacheSize * multiplier
 
-				if len(results) > 0 {
-					printResults(results)
-					results = results[:0]
-				}
-
 				for _, newCache := range newCache {
 					result := run(newGen, cacheSize, numKey, newCache)
 					results = append(results, result)
+				}
+
+				if len(results) > 0 {
+					printResults(results)
+					results = results[:0]
 				}
 			}
 		}


### PR DESCRIPTION
Hello!

Thanks for the benchmark. I tried it and noticed that the results of the last run are not printed on the screen. This patch fixes the issue.